### PR TITLE
allow multiple URLs for CF_TARGET

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Cloud Foundry Certificate Truster 1.0.2.BUILD-SNAPSHOT
-Copyright (c) 2015-2015 Pivotal Software, Inc.
+Copyright (c) 2015-2016 Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/README.adoc
+++ b/README.adoc
@@ -36,6 +36,8 @@ CF_TARGET=https://api.my-cf-domain.com
 This will cause `CloudFoundryCertificateTruster` to download the certificate at api.my-cf-domain.com:443 and add
 it to the JVM's truststore.
 
+Multiple URLs can be specified using comma (,) as a delimiter.
+
 NOTE: The timeout for certificate download is 5 seconds. If any errors occur, they are printed to System.err.
 
 == Build

--- a/src/main/java/io/pivotal/springcloud/ssl/CloudFoundryCertificateTruster.java
+++ b/src/main/java/io/pivotal/springcloud/ssl/CloudFoundryCertificateTruster.java
@@ -48,24 +48,31 @@ public class CloudFoundryCertificateTruster implements ApplicationContextInitial
 	void trustCertificatesInternal() {
 		String cfTarget = env.getValue("CF_TARGET");
 		if (cfTarget != null) {
-			try {
-				URL cfTargetUrl = new URL(cfTarget);
-				String host = cfTargetUrl.getHost();
-				if ("https".equals(cfTargetUrl.getProtocol()) && host != null) {
-					int httpsPort = cfTargetUrl.getPort() > 0 ? cfTargetUrl.getPort() : 443;
-					try {
-						sslCertificateTruster.trustCertificateInternal(host, httpsPort, 5000);
-					} catch (Exception e) {
-						System.err.println("trusting certificate at " + host + ":" + httpsPort + " failed due to " + e);
-						e.printStackTrace();
-					}
-				}
-			} catch (MalformedURLException e1) {
-				System.err.println("Cannot parse CF_TARGET '"+cfTarget+"' as a URL");
+			String[] cfTargets = cfTarget.split(",");
+			for (String target : cfTargets) {
+				trustCertificateInternal(target);
 			}
 		}
 	}
 
+	void trustCertificateInternal(String target) {
+		try {
+			URL cfTargetUrl = new URL(target);
+			String host = cfTargetUrl.getHost();
+			if ("https".equals(cfTargetUrl.getProtocol()) && host != null) {
+				int httpsPort = cfTargetUrl.getPort() > 0 ? cfTargetUrl.getPort() : 443;
+				try {
+					sslCertificateTruster.trustCertificateInternal(host, httpsPort, 5000);
+				} catch (Exception e) {
+					System.err.println("trusting certificate at " + host + ":" + httpsPort + " failed due to " + e);
+					e.printStackTrace();
+				}
+			}
+		} catch (MalformedURLException e1) {
+			System.err.println("Cannot parse CF_TARGET '"+target+"' as a URL");
+		}
+	}
+	
 	static {
 		trustCertificates();
 	}

--- a/src/test/java/io/pivotal/springcloud/ssl/CloudFoundryCertificateTrusterMultipleTest.java
+++ b/src/test/java/io/pivotal/springcloud/ssl/CloudFoundryCertificateTrusterMultipleTest.java
@@ -1,0 +1,78 @@
+package io.pivotal.springcloud.ssl;
+
+import io.pivotal.springcloud.ssl.CloudFoundryCertificateTruster.EnvironmentVariableResolver;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.util.ReflectionUtils;
+
+public class CloudFoundryCertificateTrusterMultipleTest {
+
+	private CloudFoundryCertificateTruster cfCertTruster;
+
+	@Mock
+	private EnvironmentVariableResolver env;
+	
+	@Mock
+	private SslCertificateTruster sslCertTruster;
+
+	@Before
+	public void setup() throws IllegalArgumentException, IllegalAccessException {
+		MockitoAnnotations.initMocks(this);
+		cfCertTruster = new CloudFoundryCertificateTruster();
+		Field envField = ReflectionUtils.findField(CloudFoundryCertificateTruster.class, "env");
+		ReflectionUtils.makeAccessible(envField);
+		ReflectionUtils.setField(envField, cfCertTruster, env);
+		Field sslCertTrusterField = ReflectionUtils.findField(CloudFoundryCertificateTruster.class,
+				"sslCertificateTruster");
+		ReflectionUtils.makeAccessible(sslCertTrusterField);
+		ReflectionUtils.setField(sslCertTrusterField, cfCertTruster, sslCertTruster);
+	}
+
+	@Test
+	public void testMultipleTargets() throws Exception {
+		
+		final String cfTargets = "https://api.foo.com,https://api.foo.com:8080";
+		final String[] expectedHosts = new String[] { "api.foo.com", "api.foo.com" };
+		final int[] expectedPorts = new int[] { 443, 8080 };
+		
+		final int count = cfTargets.split(",").length;
+		
+		Mockito.when(env.getValue("CF_TARGET")).thenReturn(cfTargets);
+
+		cfCertTruster.trustCertificatesInternal();
+
+		ArgumentCaptor<String> hostCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<Integer> portCaptor = ArgumentCaptor.forClass(int.class);
+		ArgumentCaptor<Integer> timeoutCaptor = ArgumentCaptor.forClass(int.class);
+		Mockito.verify(sslCertTruster, Mockito.times(count)).trustCertificateInternal(
+				hostCaptor.capture(),
+				portCaptor.capture(),
+				timeoutCaptor.capture());
+		
+		List<String> hosts = hostCaptor.getAllValues();
+		List<Integer> ports = portCaptor.getAllValues();
+		List<Integer> timeouts = timeoutCaptor.getAllValues();
+		
+		for (int i = 0; i < count; i++) {
+			Assert.assertEquals(expectedHosts[i], hosts.get(i));
+			Assert.assertEquals(expectedPorts[i], ports.get(i).intValue());
+			Assert.assertEquals(new Integer(5000), timeouts.get(i));
+		}
+
+	}
+
+
+}

--- a/src/test/java/io/pivotal/springcloud/ssl/CloudFoundryCertificateTrusterTest.java
+++ b/src/test/java/io/pivotal/springcloud/ssl/CloudFoundryCertificateTrusterTest.java
@@ -93,5 +93,4 @@ public class CloudFoundryCertificateTrusterTest {
 
 	}
 
-
 }


### PR DESCRIPTION
The CF_TARGET env variable is only allowed to have a single URL in it. These changes allow it to contain multiple URLs using comma as a delimiter. Example:

CF_TARGET: https://api.foo.com,https://api.foo.com:8080,https://api.foo.com:8443
