### PR TITLE
Use daemon thread instead of user thread

### DIFF
--- a/src/main/java/io/pivotal/springcloud/ssl/SslCertificateTruster.java
+++ b/src/main/java/io/pivotal/springcloud/ssl/SslCertificateTruster.java
@@ -62,7 +62,8 @@ public class SslCertificateTruster {
 
 			@Override
 			public Thread newThread(Runnable r) {
-				return new Thread(r, "SSLCertificateTruster:downloader");
+				Thread t = new Thread(r, "SSLCertificateTruster:downloader");
+				t.setDaemon(true);
 			}
 		});
 	}

--- a/src/main/java/io/pivotal/springcloud/ssl/SslCertificateTruster.java
+++ b/src/main/java/io/pivotal/springcloud/ssl/SslCertificateTruster.java
@@ -64,6 +64,7 @@ public class SslCertificateTruster {
 			public Thread newThread(Runnable r) {
 				Thread t = new Thread(r, "SSLCertificateTruster:downloader");
 				t.setDaemon(true);
+				return t;
 			}
 		});
 	}


### PR DESCRIPTION
Usage of user thread prevent application's main thread from exiting.